### PR TITLE
Implemented easydb in rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+easydb.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,19 @@ repository = "https://github.com/drewtato/easydb-rust"
 readme = "README.md"
 keywords = ["easydb"]
 categories = ["api-bindings", "database"]
-license = "MIT"
-version = "0.1.0"
+license = "MIT OR Apache-2.0"
+version = "0.2.0" # Update html_root_url when updating version
 authors = ["Drewtato <ai@andrewirino.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+# Sending requests to the DB
 reqwest = "^0.9.22"
+# Deriving serialize and deserialize
 serde = { version = "1.0", features = ["derive"] }
+# Dealing with json requests to and from the DB
 serde_json = "^1.0.41"
+# Dealing with the toml configuration file easydb.toml
 toml = "^0.5.5"
+# Errors
 error-chain = "^0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "easydb"
+description = "An iterface for working with easydb.io in rust."
+homepage = "https://github.com/drewtato/easydb-rust"
+documentation = "https://docs.rs/easydb"
+repository = "https://github.com/drewtato/easydb-rust"
+readme = "README.md"
+keywords = ["easydb"]
+categories = ["api-bindings", "database"]
+license = "MIT"
+version = "0.1.0"
+authors = ["Drewtato <ai@andrewirino.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+reqwest = "^0.9.22"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "^1.0.41"
+toml = "^0.5.5"
+error-chain = "^0.12.1"

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,0 @@
-Copyright 2019 Andrew Irino
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2019 Andrew Irino
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ An interface for working with [easydb.io](https://easydb.io) in rust.
 [Crates.io page](https://crates.io/crates/easydb)
 
 [Repository](https://github.com/drewtato/easydb-rust)
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0
+   <http://www.apache.org/licenses/LICENSE-2.0)>
+* MIT license
+   <http://opensource.org/licenses/MIT)>
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ An interface for working with [easydb.io](https://easydb.io) in rust.
 Licensed under either of
 
 * Apache License, Version 2.0
-   <http://www.apache.org/licenses/LICENSE-2.0)>
+   <http://www.apache.org/licenses/LICENSE-2.0>
 * MIT license
-   <http://opensource.org/licenses/MIT)>
+   <http://opensource.org/licenses/MIT>
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,9 @@
-# Rust-Client
-EasyDB Rust Client
+# easydb-rust
 
-This crate has not yet been implemented. If you'd like to write it, I'll pay you!
+An interface for working with [easydb.io](https://easydb.io) in rust.
 
-Just implement the following 4 functions with their respective cURLs:
+[Docs](https://docs.rs/easydb)
 
-Get: 
-```
-curl --request GET \ 
---url https://app.easydb.io/database/{database_uuid}/{key} \
--H "token:{database_token}"
-```
+[Crates.io page](https://crates.io/crates/easydb)
 
-Put: 
-```
-curl --request POST \  
-  --url https://app.easydb.io/database/{database_uuid} \
-  -H 'content-type: application/json' \
-  -H 'token: {database_token}' \
-  -d '{ 
-      "key": "somekey",
-      "value": "{asdf}"
-  }'
-```
-
-Delete:
-```
-curl --request DELETE \
-   --url https://app.easydb.io/database/{database_uuid} \
-   -H 'content-type: application/json' \
-   -H 'token: {database_token}' \
-   -d '{
-       "key": "somekey"
-   }
-```
-
-List: 
-```
-curl --request GET \ 
---url https://app.easydb.io/database/{database_uuid} \
--H "token:{database_token}"
-```
-
-If you create a PR implementing this language, I'm happy to send you $5 via Stellar.
+[Repository](https://github.com/drewtato/easydb-rust)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+hard_tabs = true

--- a/src/easydb.rs
+++ b/src/easydb.rs
@@ -1,0 +1,319 @@
+use crate::errors::{EdbError, EdbResult, EdbResultExt};
+use reqwest::{
+	header::{CONTENT_LENGTH, CONTENT_TYPE},
+	Client, Url,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+pub use serde_json::Value as Json;
+use std::{collections::HashMap, fs::read_to_string, io::Write, str::FromStr};
+#[derive(Debug, Deserialize, Serialize)]
+
+/// The main type for dealing with easydb.
+///
+/// Create an `EasyDB` using [`new`][EasyDB::new] or [`from_uuid_token`][EasyDB::from_uuid_token].
+///
+pub struct EasyDB {
+	#[serde(rename = "UUID")]
+	uuid: String,
+	#[serde(rename = "Token")]
+	token: String,
+	#[serde(skip, default = "Client::new")]
+	client: Client,
+	#[serde(rename = "URL", default = "default_url")]
+	url: String,
+}
+
+fn default_url() -> String {
+	"https://app.easydb.io/database/".to_string()
+}
+
+impl EasyDB {
+	/// Creates an EasyDB using the `easydb.toml` in the current directory.
+	///
+	/// # Errors
+	///
+	/// Will fail if the file cannot be read (e.g. when it doesn't exist), or if the UUID or URL
+	/// does not form a valid URL.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// let edb = EasyDB::new()?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn new() -> EdbResult<Self> {
+		let edb: Self = read_to_string("./easydb.toml")?.parse()?;
+		edb.validate_uuid()?;
+		Ok(edb)
+	}
+	/// Creates an EasyDB using a UUID, Token, and optional URL (defaults to
+	/// `https://app.easydb.io/database/`).
+	///
+	/// # Errors
+	///
+	/// Will fail if `url` or `uuid` don't form a valid URL.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// let edb = EasyDB::from_uuid_token("aaaa...".to_string(), "bbbb...".to_string(), None);
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn from_uuid_token(uuid: String, token: String, url: Option<String>) -> EdbResult<Self> {
+		let edb = Self {
+			uuid,
+			token,
+			client: Client::new(),
+			url: url.unwrap_or_else(default_url),
+		};
+		edb.url.parse::<Url>()?;
+		edb.validate_uuid()?;
+		Ok(edb)
+	}
+	fn validate_uuid(&self) -> EdbResult<()> {
+		self.url.parse::<Url>().unwrap().join(&self.uuid)?;
+		Ok(())
+	}
+	fn create_key_url(&self, key: &str) -> EdbResult<Url> {
+		self.url
+			.parse::<Url>()
+			.unwrap()
+			.join(&format!("{}/", self.uuid))
+			.unwrap()
+			.join(key)
+			.chain_err(|| format!("Invalid key: {}", key))
+	}
+	/// Returns the stored UUID.
+	pub fn uuid(&self) -> &str {
+		&self.uuid
+	}
+	/// Returns the stored token.
+	pub fn token(&self) -> &str {
+		&self.token
+	}
+	/// Returns the stored URL.
+	pub fn url(&self) -> &str {
+		&self.url
+	}
+
+	/// Gets the value associated with `key`.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # let edb = EasyDB::new()?;
+	/// let s = edb.get("somekey")?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn get(&self, key: &str) -> EdbResult<String> {
+		self.get_json(key)?
+			.as_str()
+			.map(|s| s.to_string())
+			.ok_or_else(|| "Value was not a string".into())
+	}
+	/// Gets the value associated with `key` in json format.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # let edb = EasyDB::new()?;
+	/// let json = edb.get_json("somekey")?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn get_json(&self, key: &str) -> EdbResult<Json> {
+		let mut s = Vec::new();
+		self.get_writer(key, &mut s)?;
+		Ok(serde_json::from_slice(&s)?)
+	}
+	/// Assigns `value` to `key` and returns the status code.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # let edb = EasyDB::new()?;
+	/// let status = edb.put("somekey", "somevalue")?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn put(&self, key: &str, value: &str) -> EdbResult<u16> {
+		let new_value = json!(value);
+		self.put_json(key, new_value)
+	}
+	/// Assigns a json `value` to `key` and returns the status code.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # use serde_json::json;
+	/// # let edb = EasyDB::new()?;
+	/// let status = edb.put_json("somekey", json!({"a": "b"}))?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn put_json(&self, key: &str, value: Json) -> EdbResult<u16> {
+		let body = json!({ "value": value }).to_string();
+		Ok(self
+			.client
+			.post(self.create_key_url(key)?)
+			.header(CONTENT_TYPE, "application/json")
+			.header(CONTENT_LENGTH, body.len())
+			.header("token", &self.token)
+			.body(body)
+			.send()?
+			.status()
+			.as_u16())
+	}
+	/// Deletes the value associated with `key` and returns the status code.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # let edb = EasyDB::new()?;
+	/// let status = edb.delete("somekey")?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn delete(&self, key: &str) -> EdbResult<u16> {
+		Ok(self
+			.client
+			.delete(self.create_key_url(key)?)
+			.header(CONTENT_TYPE, "application/json")
+			.header("token", &self.token)
+			.send()?
+			.status()
+			.as_u16())
+	}
+	/// Returns a `HashMap<String, String>` of all the data in this database.
+	///
+	/// # Errors
+	///
+	/// Will fail if any of the values are not strings.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # let edb = EasyDB::new()?;
+	/// let map = edb.list()?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn list(&self) -> EdbResult<HashMap<String, String>> {
+		self.list_json()?
+			.drain()
+			.map(|(s, v)| match v.as_str() {
+				Some(v_str) => Ok((s, v_str.to_string())),
+				None => Err(format!("A value was not a string: key: {}, value: {}", s, v).into()),
+			})
+			.collect()
+	}
+	/// Returns a `HashMap<String, Json>` of all the data in this database.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # let edb = EasyDB::new()?;
+	/// let map = edb.list()?;
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn list_json(&self) -> EdbResult<HashMap<String, Json>> {
+		let mut s = Vec::new();
+		self.list_writer(&mut s)?;
+		Ok(serde_json::from_slice(&s)?)
+	}
+	/// Clears the database.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// # let edb = EasyDB::new()?;
+	/// edb.clear()?;
+	/// # std::thread::sleep(std::time::Duration::from_secs(1));
+	/// assert_eq!(edb.list()?.len(), 0);
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	pub fn clear(&self) -> EdbResult<()> {
+		let map = self.list_json()?;
+		self.clear_keys(map.keys().map(|k| &k[..]))?;
+		Ok(())
+	}
+	fn clear_keys<'a, I>(&self, keys: I) -> EdbResult<()>
+	where
+		I: Iterator<Item = &'a str>,
+	{
+		for key in keys {
+			self.delete(key)?;
+		}
+		Ok(())
+	}
+	/// An alternative to `get()` that works with a writer. Fetches data associated with `key` and
+	/// writes into `value`, returning the status code.
+	///
+	/// The response should have the value that was originally set in JSON form. If the key was
+	/// never set, was deleted, or has no data, the response will be an empty string: `""`.
+	pub fn get_writer<W>(&self, key: &str, value: &mut W) -> EdbResult<u16>
+	where
+		W: Write,
+	{
+		let mut resp = self
+			.client
+			.get(self.create_key_url(key)?)
+			.header("token", &self.token)
+			.send()?;
+		resp.copy_to(value)?;
+		Ok(resp.status().as_u16())
+	}
+	/// An alternative to `list()` that works with a writer. Fetches all the data in the database
+	/// and writes it to `list`, returning the status code.
+	pub fn list_writer<W>(&self, list: &mut W) -> EdbResult<u16>
+	where
+		W: Write,
+	{
+		let mut resp = self
+			.client
+			.get(self.url.parse::<Url>().unwrap().join(&self.uuid).unwrap())
+			.header("token", &self.token)
+			.send()?;
+		resp.copy_to(list)?;
+		Ok(resp.status().as_u16())
+	}
+}
+
+impl FromStr for EasyDB {
+	type Err = EdbError;
+	/// Create an `EasyDB` from a `&str` in the TOML format.
+	///
+	/// # Example
+	///
+	/// ```
+	/// # use crate::easydb::{EasyDB, errors::EdbError};
+	/// let s = r#"
+	/// UUID = "abcd"
+	/// Token = "efgh"
+	/// "#;
+	/// let edb: EasyDB = s.parse()?;
+	/// assert_eq!(edb.uuid(), "abcd");
+	/// assert_eq!(edb.token(), "efgh");
+	/// # Ok::<(), EdbError>(())
+	/// ```
+	///
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(toml::from_str(s)?)
+	}
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,15 @@
+use error_chain::error_chain;
+
+error_chain! {
+	types {
+		EdbError, EdbErrorKind, EdbResultExt, EdbResult;
+	}
+	foreign_links {
+		Fs(toml::de::Error);
+		Io(std::io::Error);
+		Request(reqwest::Error);
+		Url(reqwest::UrlError);
+		FromUtf8(std::string::FromUtf8Error);
+		FromJson(serde_json::Error);
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,296 @@
+//! An interface for working with [easydb.io](https://easydb.io) in rust.
+//!
+//! # Quick start
+//!
+//! ```
+//! # use std::collections::HashMap;
+//! use easydb::EasyDB;
+//! 
+//! // Create an EasyDB struct to interact with.
+//! // Gets information from `./easydb.toml`.
+//! let edb: EasyDB = EasyDB::new().unwrap();
+//!
+//! // Store some data
+//!	edb.put("hello", "world").unwrap();
+//!	edb.put("goodbye", "earth").unwrap();
+//!
+//! // Get a single item
+//! let stored_hello: String = edb.get("hello").unwrap();
+//! assert_eq!(&stored_hello, "world");
+//!
+//! // Update an item
+//! edb.put("goodbye", "dirt").unwrap();
+//! assert_eq!(&edb.get("goodbye").unwrap(), "dirt");
+//!
+//! // Get a HashMap of all database entries
+//!	let resp: HashMap<String, String> = edb.list().unwrap();
+//!	assert_eq!(&resp["hello"], "world");
+//!	assert_eq!(&resp["goodbye"], "dirt");
+//!
+//! // Delete items
+//!	edb.delete("hello").unwrap();
+//! let deleted_item: String = edb.get("hello").unwrap();
+//! assert_eq!(&deleted_item, "");
+//! ```
+//!
+//! # Commands
+//!
+//! The easiest way to create an [`EasyDB`][EasyDB] is to call [`EasyDB::new()`][EasyDB::new].
+//! This generates the struct using data in `./easydb.toml`, which should include the following
+//! information:
+//!
+//! ```toml
+//! UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+//! Token = "ffffffff-0000-1111-2222-333333333333"
+//! URL = "https://app.easydb.io/database/"
+//! ```
+//!
+//! The `URL` field is optional and will default to `https://app.easydb.io/database/`.
+//!
+//! If your toml is not at the default location, you can just
+//! [`parse`](./struct.EasyDB.html#method.from_str) it. For example:
+//!
+//! ```
+//! # use easydb::EasyDB;
+//! let edb: EasyDB = "UUID = \"aaaa...\"\nToken = \"ffff...\"".parse().unwrap();
+//! ```
+//!
+//! If you have individual items, you can initalize an [`EasyDB`][EasyDB] with
+//! [`from_uuid_token`][EasyDB::from_uuid_token]:
+//!
+//! ```
+//! # use easydb::EasyDB;
+//! let edb = EasyDB::from_uuid_token("aaaa...".to_string(), "ffff...".to_string(), None);
+//! ```
+//!
+//! ## Using the EasyDB
+//!
+//! The four methods **`get`**, **`put`**, **`delete`**, and **`list`** correspond to the four 
+//! available APIs in `easydb.io`. `get` and `delete` take one argument: a key. `put` takes two 
+//! arguments: a `key` and a `value`. `list` takes no arguments. Example usage can be seen in the 
+//! [Quick start](#quick-start) section at the top of this page.
+//!
+//! ## Errors
+//!
+//! All network errors as reported by the `reqwest` crate are returned in `Result`s. Other errors
+//! are documented on their respective methods.
+//!
+
+use std::{collections::HashMap, fs::read_to_string, io::Write, str::FromStr};
+
+use reqwest::{
+	header::{CONTENT_LENGTH, CONTENT_TYPE},
+	Client, Url,
+};
+use serde::{Deserialize, Serialize};
+#[macro_use]
+extern crate error_chain;
+
+mod errors {
+	error_chain! {
+		types {
+			EdbError, EdbErrorKind, EdbResultExt, EdbResult;
+		}
+		foreign_links {
+			Fs(toml::de::Error);
+			Io(std::io::Error);
+			Request(reqwest::Error);
+			Url(reqwest::UrlError);
+			FromUtf8(std::string::FromUtf8Error);
+			FromJson(serde_json::Error);
+		}
+	}
+}
+
+pub use errors::{EdbError, EdbErrorKind, EdbResult, EdbResultExt};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EasyDB {
+	#[serde(rename = "UUID")]
+	uuid: String,
+	#[serde(rename = "Token")]
+	token: String,
+	#[serde(skip, default = "Client::new")]
+	client: Client,
+	#[serde(rename = "URL", default = "default_url")]
+	url: String,
+}
+
+fn default_url() -> String {
+	"https://app.easydb.io/database/".to_string()
+}
+
+impl EasyDB {
+	/// Creates an EasyDB using the `easydb.toml` in the current directory.
+	///
+	/// # Errors
+	///
+	/// Will fail if the file cannot be read (e.g. when it doesn't exist), or if the uuid does not
+	/// form a valid URL.
+	pub fn new() -> EdbResult<Self> {
+		let edb: Self = read_to_string("./easydb.toml")?.parse()?;
+		edb.validate_uuid()?;
+		Ok(edb)
+	}
+
+	/// Creates an EasyDB using a UUID, Token, and optional URL (defaults to
+	/// `https://app.easydb.io/database/`).
+	///
+	/// # Errors
+	///
+	/// Will fail if `url` or `uuid` don't form a valid URL.
+	pub fn from_uuid_token(uuid: String, token: String, url: Option<String>) -> EdbResult<Self> {
+		let edb = Self {
+			uuid,
+			token,
+			client: Client::new(),
+			url: url.unwrap_or_else(default_url),
+		};
+		edb.url.parse::<Url>()?;
+		edb.validate_uuid()?;
+		Ok(edb)
+	}
+
+	fn validate_uuid(&self) -> EdbResult<()> {
+		self.url.parse::<Url>().unwrap().join(&self.uuid)?;
+		Ok(())
+	}
+
+	fn create_key_url(&self, key: &str) -> EdbResult<Url> {
+		self.url
+			.parse::<Url>()
+			.unwrap()
+			.join(&format!("{}/", self.uuid))
+			.unwrap()
+			.join(key)
+			.chain_err(|| format!("Invalid key: {}", key))
+	}
+
+	/// Fetches data associated with `key` and returns it as a `String`. Missing keys are returned
+	/// as an empty string.
+	///
+	/// # Errors
+	///
+	/// Will fail if the data does not form a valid UTF8 string. If your data is not supposed to,
+	/// use [`get_writer`][EasyDB::get_writer].
+	pub fn get(&self, key: &str) -> EdbResult<String> {
+		let mut s = Vec::new();
+		self.get_writer(key, &mut s)?;
+		// Values will always be surrounded by quotes.
+		Ok(String::from_utf8(s[1..s.len() - 1].to_vec())?)
+	}
+	/// Writes `value` to `key` and returns the status code.
+	pub fn put(&self, key: &str, value: &str) -> EdbResult<u16> {
+		let body = format!(r#"{{"value":"{}"}}"#, value);
+		Ok(self
+			.client
+			.post(self.create_key_url(key)?)
+			.header(CONTENT_TYPE, "application/json")
+			.header(CONTENT_LENGTH, body.len())
+			.header("token", &self.token)
+			.body(body)
+			.send()?
+			.status()
+			.as_u16())
+	}
+
+	/// Deletes data associated with `key` and returns the status code.
+	pub fn delete(&self, key: &str) -> EdbResult<u16> {
+		Ok(self
+			.client
+			.delete(self.create_key_url(key)?)
+			.header(CONTENT_TYPE, "application/json")
+			.header("token", &self.token)
+			.send()?
+			.status()
+			.as_u16())
+	}
+
+	/// Returns a HashMap of all the data in this database.
+	///
+	/// # Errors
+	///
+	/// Will fail if the data does not form a valid UTF8 string. If your data is not supposed to,
+	/// use [`list_writer`][EasyDB::list_writer]. Also will fail if the data is not valid JSON.
+	pub fn list(&self) -> EdbResult<HashMap<String, String>> {
+		let mut s = Vec::new();
+		self.list_writer(&mut s)?;
+		Ok(serde_json::from_str(&String::from_utf8(s)?)?)
+	}
+
+	/// An alternative to `get()` that works with a writer. Fetches data associated with `key` and
+	/// writes into `value`, returning the status code.
+	/// 
+	/// The response should have the value that was originally sent, surrounded by quotes (`"`). If
+	/// the key was never set or has no data, the response will be `""`.
+	pub fn get_writer<W>(&self, key: &str, value: &mut W) -> EdbResult<u16>
+	where
+		W: Write,
+	{
+		let mut resp = self
+			.client
+			.get(self.create_key_url(key)?)
+			.header("token", &self.token)
+			.send()?;
+		resp.copy_to(value)?;
+		Ok(resp.status().as_u16())
+	}
+	/// An alternative to `list()` that works with a writer. Fetches all the data in the database
+	/// and writes it to `list`, returning the status code.
+	pub fn list_writer<W>(&self, list: &mut W) -> EdbResult<u16>
+	where
+		W: Write,
+	{
+		let mut resp = self
+			.client
+			.get(self.url.parse::<Url>().unwrap().join(&self.uuid).unwrap())
+			.header("token", &self.token)
+			.send()?;
+		resp.copy_to(list)?;
+		Ok(resp.status().as_u16())
+	}
+}
+
+impl FromStr for EasyDB {
+	type Err = EdbError;
+
+	/// Create an `EasyDB` from a `&str` in the TOML format.
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(toml::from_str(s)?)
+	}
+}
+
+// Note that in order to run tests, you must create an `easydb.toml` in the current directory.
+#[cfg(test)]
+mod tests {
+	use crate::EasyDB;
+	#[test]
+	fn edb_from_toml() {
+		let s = r#"
+			UUID = "abcd"
+			Token = "efgh"
+		"#;
+		let edb: EasyDB = s.parse().unwrap();
+		assert_eq!(&edb.uuid, "abcd");
+		assert_eq!(&edb.token, "efgh");
+	}
+
+	#[test]
+	fn list() {
+		let edb = EasyDB::new().unwrap();
+		edb.put("hello", "world").unwrap();
+		edb.put("goodbye", "earth").unwrap();
+		assert_eq!(&edb.get("hello").unwrap(), "world");
+
+		let resp = edb.list().unwrap();
+		assert_eq!(&resp["hello"], "world");
+		assert_eq!(&resp["goodbye"], "earth");
+
+		edb.delete("hello").unwrap();
+		edb.delete("goodbye").unwrap();
+		let resp = edb.list().unwrap();
+
+		assert!(resp.get("hello").is_none());
+		assert!(resp.get("goodbye").is_none());
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,36 +1,48 @@
+#![doc(html_root_url = "https://docs.rs/easydb/0.2.0")]
+
 //! An interface for working with [easydb.io](https://easydb.io) in rust.
 //!
 //! # Quick start
 //!
 //! ```
 //! # use std::collections::HashMap;
+//! # use crate::easydb::errors::EdbError;
 //! use easydb::EasyDB;
-//! 
+//!
 //! // Create an EasyDB struct to interact with.
 //! // Gets information from `./easydb.toml`.
-//! let edb: EasyDB = EasyDB::new().unwrap();
+//! let edb: EasyDB = EasyDB::new()?;
+//! # edb.clear()?;
+//! #
+//! # std::thread::sleep(std::time::Duration::from_secs(1));
 //!
 //! // Store some data
-//!	edb.put("hello", "world").unwrap();
-//!	edb.put("goodbye", "earth").unwrap();
+//!	edb.put("hello", "world")?;
+//!	edb.put("goodbye", "earth")?;
+//! #
+//! # std::thread::sleep(std::time::Duration::from_secs(1));
 //!
 //! // Get a single item
-//! let stored_hello: String = edb.get("hello").unwrap();
+//! let stored_hello: String = edb.get("hello")?;
 //! assert_eq!(&stored_hello, "world");
 //!
 //! // Update an item
-//! edb.put("goodbye", "dirt").unwrap();
-//! assert_eq!(&edb.get("goodbye").unwrap(), "dirt");
+//! edb.put("goodbye", "dirt")?;
+//! # std::thread::sleep(std::time::Duration::from_secs(1));
+//! assert_eq!(&edb.get("goodbye")?, "dirt");
 //!
 //! // Get a HashMap of all database entries
-//!	let resp: HashMap<String, String> = edb.list().unwrap();
+//!	let resp: HashMap<String, String> = edb.list()?;
 //!	assert_eq!(&resp["hello"], "world");
 //!	assert_eq!(&resp["goodbye"], "dirt");
 //!
 //! // Delete items
-//!	edb.delete("hello").unwrap();
-//! let deleted_item: String = edb.get("hello").unwrap();
+//!	edb.delete("hello")?;
+//! # std::thread::sleep(std::time::Duration::from_secs(1));
+//! let deleted_item: String = edb.get("hello")?;
 //! assert_eq!(&deleted_item, "");
+//! # edb.clear()?;
+//! # Ok::<(), EdbError>(())
 //! ```
 //!
 //! # Commands
@@ -48,7 +60,7 @@
 //! The `URL` field is optional and will default to `https://app.easydb.io/database/`.
 //!
 //! If your toml is not at the default location, you can just
-//! [`parse`](./struct.EasyDB.html#method.from_str) it. For example:
+//! [`parse`](./struct.EasyDB.html#method.from_str) it from a string in toml format. For example:
 //!
 //! ```
 //! # use easydb::EasyDB;
@@ -63,234 +75,89 @@
 //! let edb = EasyDB::from_uuid_token("aaaa...".to_string(), "ffff...".to_string(), None);
 //! ```
 //!
-//! ## Using the EasyDB
+//! ## Using EasyDB
 //!
-//! The four methods **`get`**, **`put`**, **`delete`**, and **`list`** correspond to the four 
-//! available APIs in `easydb.io`. `get` and `delete` take one argument: a key. `put` takes two 
-//! arguments: a `key` and a `value`. `list` takes no arguments. Example usage can be seen in the 
-//! [Quick start](#quick-start) section at the top of this page.
+//! The four methods [**`get`**][EasyDB::get], [**`put`**][EasyDB::put],
+//! [**`delete`**][EasyDB::delete], and [**`list`**][EasyDB::list] correspond to the four available
+//! APIs in `easydb.io`. `get` and `delete` take one argument: a key. `put` takes two arguments: a
+//! `key` and a `value`. `list` takes no arguments. Example usage can be seen in the
+//! [quick start](#quick-start) section at the top of this page.
+//!
+//! The above methods deal with [`String`](https://doc.rust-lang.org/std/string/struct.String.html) 
+//! values and will fail if any value is not a JSON string. If you would like to use JSON, there are 
+//! [**`get_json`**][EasyDB::get_json], [**`put_json`**][EasyDB::put_json], and 
+//! [**`list_json`**][EasyDB::list_json] ([**`delete`**][EasyDB::delete] is the same). These deal 
+//! with `value`s that are of the `Json` type, which is a re-export of the 
+//! [`Value`](https://docs.serde.rs/serde_json/enum.Value.html) type from `serde_json`.
+//!
+//! In addition, there is the [**`clear`**][EasyDB::clear] method for easily clearing the entire
+//! database, which, for example, is useful when initializing the database. This just calls
+//! [`delete`][EasyDB::delete] on every item, but if easydb.io implements a clear function in the
+//! future, this will call it.
 //!
 //! ## Errors
 //!
 //! All network errors as reported by the `reqwest` crate are returned in `Result`s. Other errors
 //! are documented on their respective methods.
 //!
+//! Due to the unknown nature of the database, there may be unexpected results when reading data
+//! just after writing data. Expect that read values will be either up-to-date or old values.
+//!
 
-use std::{collections::HashMap, fs::read_to_string, io::Write, str::FromStr};
+mod easydb;
+pub use crate::easydb::EasyDB;
 
-use reqwest::{
-	header::{CONTENT_LENGTH, CONTENT_TYPE},
-	Client, Url,
-};
-use serde::{Deserialize, Serialize};
-#[macro_use]
-extern crate error_chain;
+/// Re-exported [`Value`](https://docs.serde.rs/serde_json/enum.Value.html) type from serde_json.
+pub use crate::easydb::Json;
 
-mod errors {
-	error_chain! {
-		types {
-			EdbError, EdbErrorKind, EdbResultExt, EdbResult;
-		}
-		foreign_links {
-			Fs(toml::de::Error);
-			Io(std::io::Error);
-			Request(reqwest::Error);
-			Url(reqwest::UrlError);
-			FromUtf8(std::string::FromUtf8Error);
-			FromJson(serde_json::Error);
-		}
-	}
-}
-
-pub use errors::{EdbError, EdbErrorKind, EdbResult, EdbResultExt};
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct EasyDB {
-	#[serde(rename = "UUID")]
-	uuid: String,
-	#[serde(rename = "Token")]
-	token: String,
-	#[serde(skip, default = "Client::new")]
-	client: Client,
-	#[serde(rename = "URL", default = "default_url")]
-	url: String,
-}
-
-fn default_url() -> String {
-	"https://app.easydb.io/database/".to_string()
-}
-
-impl EasyDB {
-	/// Creates an EasyDB using the `easydb.toml` in the current directory.
-	///
-	/// # Errors
-	///
-	/// Will fail if the file cannot be read (e.g. when it doesn't exist), or if the uuid does not
-	/// form a valid URL.
-	pub fn new() -> EdbResult<Self> {
-		let edb: Self = read_to_string("./easydb.toml")?.parse()?;
-		edb.validate_uuid()?;
-		Ok(edb)
-	}
-
-	/// Creates an EasyDB using a UUID, Token, and optional URL (defaults to
-	/// `https://app.easydb.io/database/`).
-	///
-	/// # Errors
-	///
-	/// Will fail if `url` or `uuid` don't form a valid URL.
-	pub fn from_uuid_token(uuid: String, token: String, url: Option<String>) -> EdbResult<Self> {
-		let edb = Self {
-			uuid,
-			token,
-			client: Client::new(),
-			url: url.unwrap_or_else(default_url),
-		};
-		edb.url.parse::<Url>()?;
-		edb.validate_uuid()?;
-		Ok(edb)
-	}
-
-	fn validate_uuid(&self) -> EdbResult<()> {
-		self.url.parse::<Url>().unwrap().join(&self.uuid)?;
-		Ok(())
-	}
-
-	fn create_key_url(&self, key: &str) -> EdbResult<Url> {
-		self.url
-			.parse::<Url>()
-			.unwrap()
-			.join(&format!("{}/", self.uuid))
-			.unwrap()
-			.join(key)
-			.chain_err(|| format!("Invalid key: {}", key))
-	}
-
-	/// Fetches data associated with `key` and returns it as a `String`. Missing keys are returned
-	/// as an empty string.
-	///
-	/// # Errors
-	///
-	/// Will fail if the data does not form a valid UTF8 string. If your data is not supposed to,
-	/// use [`get_writer`][EasyDB::get_writer].
-	pub fn get(&self, key: &str) -> EdbResult<String> {
-		let mut s = Vec::new();
-		self.get_writer(key, &mut s)?;
-		// Values will always be surrounded by quotes.
-		Ok(String::from_utf8(s[1..s.len() - 1].to_vec())?)
-	}
-	/// Writes `value` to `key` and returns the status code.
-	pub fn put(&self, key: &str, value: &str) -> EdbResult<u16> {
-		let body = format!(r#"{{"value":"{}"}}"#, value);
-		Ok(self
-			.client
-			.post(self.create_key_url(key)?)
-			.header(CONTENT_TYPE, "application/json")
-			.header(CONTENT_LENGTH, body.len())
-			.header("token", &self.token)
-			.body(body)
-			.send()?
-			.status()
-			.as_u16())
-	}
-
-	/// Deletes data associated with `key` and returns the status code.
-	pub fn delete(&self, key: &str) -> EdbResult<u16> {
-		Ok(self
-			.client
-			.delete(self.create_key_url(key)?)
-			.header(CONTENT_TYPE, "application/json")
-			.header("token", &self.token)
-			.send()?
-			.status()
-			.as_u16())
-	}
-
-	/// Returns a HashMap of all the data in this database.
-	///
-	/// # Errors
-	///
-	/// Will fail if the data does not form a valid UTF8 string. If your data is not supposed to,
-	/// use [`list_writer`][EasyDB::list_writer]. Also will fail if the data is not valid JSON.
-	pub fn list(&self) -> EdbResult<HashMap<String, String>> {
-		let mut s = Vec::new();
-		self.list_writer(&mut s)?;
-		Ok(serde_json::from_str(&String::from_utf8(s)?)?)
-	}
-
-	/// An alternative to `get()` that works with a writer. Fetches data associated with `key` and
-	/// writes into `value`, returning the status code.
-	/// 
-	/// The response should have the value that was originally sent, surrounded by quotes (`"`). If
-	/// the key was never set or has no data, the response will be `""`.
-	pub fn get_writer<W>(&self, key: &str, value: &mut W) -> EdbResult<u16>
-	where
-		W: Write,
-	{
-		let mut resp = self
-			.client
-			.get(self.create_key_url(key)?)
-			.header("token", &self.token)
-			.send()?;
-		resp.copy_to(value)?;
-		Ok(resp.status().as_u16())
-	}
-	/// An alternative to `list()` that works with a writer. Fetches all the data in the database
-	/// and writes it to `list`, returning the status code.
-	pub fn list_writer<W>(&self, list: &mut W) -> EdbResult<u16>
-	where
-		W: Write,
-	{
-		let mut resp = self
-			.client
-			.get(self.url.parse::<Url>().unwrap().join(&self.uuid).unwrap())
-			.header("token", &self.token)
-			.send()?;
-		resp.copy_to(list)?;
-		Ok(resp.status().as_u16())
-	}
-}
-
-impl FromStr for EasyDB {
-	type Err = EdbError;
-
-	/// Create an `EasyDB` from a `&str` in the TOML format.
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		Ok(toml::from_str(s)?)
-	}
-}
+pub mod errors;
 
 // Note that in order to run tests, you must create an `easydb.toml` in the current directory.
 #[cfg(test)]
 mod tests {
-	use crate::EasyDB;
+	use crate::{errors::EdbResult, EasyDB};
+	use serde_json::json;
 	#[test]
-	fn edb_from_toml() {
-		let s = r#"
-			UUID = "abcd"
-			Token = "efgh"
-		"#;
-		let edb: EasyDB = s.parse().unwrap();
-		assert_eq!(&edb.uuid, "abcd");
-		assert_eq!(&edb.token, "efgh");
+	fn list() -> EdbResult<()> {
+		let edb = EasyDB::new()?;
+		edb.clear()?;
+		edb.put("hello", "world")?;
+		edb.put("goodbye", "earth")?;
+		std::thread::sleep(std::time::Duration::from_secs(1));
+		assert_eq!(&edb.get("hello")?, "world");
+		let list = edb.list()?;
+		assert_eq!(&list["hello"], "world");
+		assert_eq!(&list["goodbye"], "earth");
+		edb.delete("hello")?;
+		edb.delete("goodbye")?;
+		std::thread::sleep(std::time::Duration::from_secs(1));
+		let list = edb.list()?;
+		assert!(list.get("hello").is_none());
+		assert!(list.get("goodbye").is_none());
+		Ok(())
 	}
-
 	#[test]
-	fn list() {
-		let edb = EasyDB::new().unwrap();
-		edb.put("hello", "world").unwrap();
-		edb.put("goodbye", "earth").unwrap();
-		assert_eq!(&edb.get("hello").unwrap(), "world");
-
-		let resp = edb.list().unwrap();
-		assert_eq!(&resp["hello"], "world");
-		assert_eq!(&resp["goodbye"], "earth");
-
-		edb.delete("hello").unwrap();
-		edb.delete("goodbye").unwrap();
-		let resp = edb.list().unwrap();
-
-		assert!(resp.get("hello").is_none());
-		assert!(resp.get("goodbye").is_none());
+	fn list_json() -> EdbResult<()> {
+		let edb = EasyDB::new()?;
+		edb.clear()?;
+		edb.put_json("hello", json!("world"))?;
+		edb.put_json(
+			"goodbye",
+			json!({
+				"a": "b",
+				"c": ["d", "e"]
+			}),
+		)?;
+		std::thread::sleep(std::time::Duration::from_secs(1));
+		let list = edb.list_json()?;
+		assert_eq!(list["hello"], json!("world"));
+		assert_eq!(
+			list["goodbye"],
+			json!({
+				"a": "b",
+				"c": ["d", "e"]
+			})
+		);
+		Ok(())
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,103 @@
+//! An example usage of easydb using an interactive prompt
+
+mod easydb;
+use crate::easydb::EasyDB;
+use std::{
+	env::args,
+	io::{stdin, stdout, Write},
+};
+mod errors;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let edb;
+	let args: Vec<_> = args().collect();
+	match args.len() {
+		1 => loop {
+			match EasyDB::new() {
+				Ok(x) => {
+					edb = x;
+					break;
+				}
+				Err(e) => {
+					eprintln!("{}", e);
+					eprintln!("Make sure `easydb.toml` exists, then press enter.");
+					input();
+				}
+			}
+		},
+		3 => edb = { EasyDB::from_uuid_token(args[1].clone(), args[2].clone(), None)? },
+		4 => {
+			edb = EasyDB::from_uuid_token(args[1].clone(), args[2].clone(), Some(args[3].clone()))?
+		}
+		_ => {
+			eprintln!("Invalid args, accepts 0, 2, or 3 arguments: [<UUID> <Token> [URL]]");
+			std::process::exit(1);
+		}
+	}
+	println!("EasyDB interactive prompt");
+	println!("-----------------------------------");
+	println!("    Commands:");
+	println!("    get      Get a value by key");
+	println!("    put      Set a key to a value");
+	println!("    del      Delete an item by key");
+	println!("    list     List all items in DB");
+	println!("    clear    Delete all items");
+	println!("    uuid     Get UUID");
+	println!("    token    Get token");
+	println!("    url      Get URL");
+	println!("    exit     Exit the program");
+	println!();
+	loop {
+		print!("> ");
+		stdout().flush()?;
+		match &input()[..] {
+			"get" => {
+				print!("Key:");
+				stdout().flush()?;
+				println!("{}", edb.get(&input())?);
+			}
+			"put" => {
+				print!("Key:");
+				stdout().flush()?;
+				let key = input();
+				print!("Value:");
+				stdout().flush()?;
+				println!("Code: {}", edb.put(&key, &input())?);
+			}
+			"del" => {
+				print!("Key:");
+				stdout().flush()?;
+				println!("Code: {}", edb.delete(&input())?);
+			}
+			"list" => {
+				for (key, val) in edb.list()?.drain() {
+					println!("{}: {}", key, val);
+				}
+			}
+			"clear" => {
+				edb.clear()?;
+				println!("Success");
+			}
+			"uuid" => {
+				println!("{}", edb.uuid());
+			}
+			"token" => {
+				println!("{}", edb.token());
+			}
+			"url" => {
+				println!("{}", edb.url());
+			}
+			"exit" => {
+				break;
+			}
+			_ => println!("Invalid command."),
+		}
+	}
+	Ok(())
+}
+
+fn input() -> String {
+	let mut s = String::new();
+	stdin().read_line(&mut s).unwrap();
+	s.trim().to_string()
+}


### PR DESCRIPTION
Hello, I've created a Rust version for easydb.

I tried to get it to work according to the curl examples, but it seems like having the key in the request body doesn't work. This implementation puts it in the URL and only has the value in the body. This seemed to be what the JS framework does.

Right now it only deals with strings. It should break if a value has a quotation mark in it. I plan on fixing this tomorrow, so if you want to wait, it should be completed in 24 hours.

I can receive Stellar on my keybase account: https://keybase.io/drewtato